### PR TITLE
Adds a priority to the CornerIcon.

### DIFF
--- a/Source/Components/TodoCornerIcon.cs
+++ b/Source/Components/TodoCornerIcon.cs
@@ -18,6 +18,7 @@ namespace Todos.Source.Components
             _settings = settings;
             _todoList = todoList;
 
+            Priority = 64530307;
             Visible = true;
 
             _icon = todoList.OpenTodos.CombineWith(settings.WindowMinimized, settings.ColorMenuIcon,

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Todos",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "namespace": "valorayne.bh.todos",
   "package": "Todos.dll",
   "manifest_version": 1,


### PR DESCRIPTION
Adds a priority to the corner icon so that it generally stays in the same position at the top and allows modules like "Bag of Holding" to manage the icon.